### PR TITLE
Video details

### DIFF
--- a/Uffizi.py
+++ b/Uffizi.py
@@ -116,7 +116,174 @@ class Uffizi(object):
                                                  ,valid)
         db.commit()
         db.close()
+        
+    def __get_sort_values(self, in_title, in_sort_title):
+        if in_sort_title:
+            sort_title = in_sort_title
+        else:
+            sort_title = in_title
+            
+        sort_letter = sort_title[0:1]
+        if sort_letter in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']:
+            sort_letter = "#"
+        else:
+            sort_letter = sort_letter.upper()
+            
+        return {'sort_title':sort_title, 'sort_letter':sort_letter}
                     
+    def __build_xml(self, ps, videos):
+        items = ET.Element("items")                    
+        items.set("pageType", "show")
+        
+        # The vidoes object can contain the details for a single video, or the
+        # listing of a section.  When it's the listing of a section, extra data
+        # about each video needs to be fetched.  When it's a single video the
+        # needed data is already in the video XML.  The section listing can be
+        # determined by the fact that the MediaContainer tag contains the "art" 
+        # attribute.
+        if videos.get('art'):
+            fetch_additional = True
+        else:
+            fetch_additional = False
+        
+        for video in videos:
+            # Loop through each video in the XML from Plex and add it to the
+            # custom XML.
+            child = ET.SubElement(items, "item",
+                                 {"key":video.get("ratingKey")
+                                 ,"title":video.get("title")
+                                 ,"type":video.get("type")
+                                 })                 
+                               
+            if video.get("titleSort"):
+                sort_title = video.get("titleSort")
+            else:
+                sort_title = video.get("title")
+                
+            sort_letter = sort_title[0:1]
+            if sort_letter in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']:
+                sort_letter = "#"
+            else:
+                sort_letter = sort_letter.upper()
+            
+                
+            child.set("sortTitle", sort_title)
+            child.set("sortLetter", sort_letter)
+                
+            if video.get("childCount"):
+                child.set("childCount", video.get("childCount"))
+            else:
+                child.set('childCount', "0")
+            
+            if video.get("art"):
+                child.set("art", video.get("art"))
+                
+            if video.get("thumb"):
+                child.set("thumb", video.get("thumb"))
+                                    
+            # Get XML on the show in order to get the collection and genre info.
+            # If the XML being built is for a details page, then the info for
+            # collections and genres is already included in the videos object.
+            # This object contains a "Location" element, which isn't present in
+            # the XML for the non-details page.  Only proceed with getting the
+            # additional data if the "Location" element isn't present.
+            if fetch_additional:
+                logger.debug('here')
+                show = ps.get_video(video.get("ratingKey"))
+            else:
+                logger.debug('there')
+                show = video
+            
+            lists = ET.SubElement(child, "lists")
+            for g in show.iter("Genre"):
+                list_item = ET.SubElement(lists, "list_item",
+                                         {"key":g.get("id")
+                                         ,"title":g.get("tag")
+                                         ,"filter":g.get("filter")
+                                         ,"type":"genre"
+                                         })
+                                 
+            for c in show.iter("Collection"):
+                list_item = ET.SubElement(lists, "list_item",
+                                          {"key":c.get("id")
+                                          ,"title":c.get("tag")
+                                          ,"filter":c.get("filter")
+                                          ,'type':'collection'
+                                          })
+            
+            # If the childCount is greater than zero there are seasons or albums
+            # associated with this item.  Fetch them and add them to the XML.
+            if int(child.get('childCount')) > 0:
+                seasons_element = ET.SubElement(child, "seasons")
+                
+                seasons = ps.get_video_children(video.get("ratingKey"))
+                
+                for season in seasons:
+                    logger.debug('Key : {0}'.format(season.get('ratingKey')))
+                    logger.debug('Title : {0}'.format(season.get('title')))
+                    logger.debug('Thumb : {0}'.format(season.get('thumb')))
+                    logger.debug('Art : {0}'.format(season.get('art')))
+                    
+                    if season.get('ratingKey'):
+                        season_element = ET.SubElement(seasons_element, 'season',
+                                                      {'key':season.get('ratingKey')
+                                                      ,'title':season.get('title')
+                                                      ,'thumb':season.get('thumb')
+                                                      ,'art':season.get('art')
+                                                      })
+                        
+        # Get the list of playlists
+        plex_playlists = ps.get_playlists()
+        
+        # Loop through each playlist and get the individual items in the list.
+        for plex_playlist in plex_playlists:
+            playlist_title = plex_playlist.get("title")
+            playlist_key = plex_playlist.get("key")
+            playlist_rating_key = plex_playlist.get("ratingKey")
+                            
+            # Get the individual items that make up the playlist.
+            plex_playlist_items = ps.get_playlist_items(playlist_key)
+            
+            # Loop through each item in the playlist.
+            for pl_video in plex_playlist_items:
+                rating_key = pl_video.get("ratingKey")
+                gp_rating_key = pl_video.get("grandparentRatingKey")
+                
+                # Check if the grandparent key is populated.  If it is, 
+                # this item is an episode or song.  In that case, we use
+                # the grandparent key as that is the TV show or artist that
+                # this item belongs to.
+                if not gp_rating_key:
+                    key_for_item = rating_key
+                else:
+                    key_for_item = gp_rating_key
+                                        
+                # Loop through the items XML looking for the video that's in 
+                # the playlist.  If found, add the playlist to the playlist 
+                # tags in the XML for the video.
+                for i in items:
+                    # See if this particular item is the one that's in the 
+                    # playlist
+                    if i.get("key") == key_for_item:
+                        # Determine if the playlist has been added to the
+                        # lists XML for the item.
+                        found = False
+                        
+                        ## Loop through the list items for this video
+                        for li in i.iter("list_item"):
+                            if li.get("key") == playlist_rating_key:
+                                found = True
+                            
+                        if not found:
+                            for l in i.iter("lists"):
+                                list_item = ET.SubElement(l, "list_item",
+                                                        {"key":playlist_rating_key
+                                                        ,"title":playlist_title
+                                                        ,'type':'playlist'
+                                                        ,'filter':playlist_key
+                                                        })
+        return items
+        
     @cherrypy.expose
     def index(self):
         raise cherrypy.HTTPRedirect("home")
@@ -177,123 +344,148 @@ class Uffizi(object):
         
         if ps.simple_status == "down":
             raise cherrypy.HTTPRedirect("error?error=SERVER_UNREACHABLE")
-        else:
-            server_template = lookup.get_template("server.html")
-            return server_template.render(server=server, videos=ps.get_sections())
+        
+        items = ET.Element('items')
+        items.set('pageType', 'server')
+        
+        sections = ps.get_sections()
+        
+        for section in sections:
+            child = ET.SubElement(items, 'item',
+                                 {'key':section.get('key')
+                                 ,'title':section.get('title')
+                                 ,'type':section.get('type')
+                                 })
+                                 
+            sort_values = self.__get_sort_values(section.get('title'), section.get('sortTitle'))
+            child.set('sortTitle', sort_values['sort_title'])
+            child.set('sortLetter', sort_values['sort_letter'])
+            
+            if section.get('art'):
+                child.set('art', section.get('art'))
+                
+            if section.get('thumb'):
+                child.set('thumb', section.get('thumb'))
+            
+        logger.debug(ET.tostring(items))
+        
+        server_template = lookup.get_template("server.html")
+        return server_template.render(server=server, items=items)
         
     @cherrypy.expose
-    def section(self, server="localhost", key="1", section="<empty>"):  
+    def section(self, server="localhost", key="1", section="<empty>"):
         ps = PlexServer(server)
         
         if ps.simple_status == "down":
             raise cherrypy.HTTPRedirect("error?error=SERVER_UNREACHABLE")
-        else:
-            cookieSet = cherrypy.response.cookie
-            
-            # Retrieve the cookie for the display mode (thumbs or list).
-            cookie_display_mode = "displayMode-" + str(server) + "-" + str(key)
-            cookie_display_mode = urllib2.quote(cookie_display_mode)
-            
-            # Use cookies to save the values of the URL parameters.  This seems 
-            # easier than trying to deconstruct the URL query string in javascript.
-            cookieSet["address"] = ps.address
-            cookieSet["port"] = ps.port
-            cookieSet["key"] = key
-            cookieSet["section"] = section
-    
-            try:
-                cookie = cherrypy.request.cookie
-                display_mode = cookie[cookie_display_mode].value
-            except KeyError:
-                display_mode = "thumbs"
-                cookieSet[cookie_display_mode] = display_mode
-            
-            # Get the items that are in this section.
-            videos = ps.get_section_items(key)
-            
-            # This will be a dictionary that will hold the other dictionaries listed
-            # below.  This will be the dictionary that will be handed off to the page
-            # template.
-            list_dict = {}
-            
-            # Build dictionaries that will hold the genres, collections, and 
-            # playlist info.  For each dictionary, the key of the dictionary is the
-            # key for the video and the value is a list that contains each of the 
-            # genre/collection/playlists the video belongs to.  For playlists, if 
-            # the item in the playlist is an episode/song, the entire show/artist 
-            # is considered part of the playlist
-            genre_dict = {}
-            coll_dict = {}
-            pl_dict = {}
-            
-            for video in videos:        
-                rating_key = video.get("ratingKey")
-                genre_dict[rating_key] = ["loading..."]
-                coll_dict[rating_key] = ["loading..."]
-                    
-            # Get the list of playlists
-            playlists = ps.get_playlists()
-            
-            # Loop through each playlist and get the individual items in the list.
-            for playlist in playlists:
-                playlist_title = playlist.get("title")
-                playlist_key = playlist.get("key")
+
+        cookieSet = cherrypy.response.cookie
+        
+        # Retrieve the cookie for the display mode (thumbs or list).
+        cookie_display_mode = "displayMode-" + str(server) + "-" + str(key)
+        cookie_display_mode = urllib2.quote(cookie_display_mode)
+        
+        # Use cookies to save the values of the URL parameters.  This seems 
+        # easier than trying to deconstruct the URL query string in javascript.
+        cookieSet["address"] = ps.address
+        cookieSet["port"] = ps.port
+        cookieSet["key"] = key
+        cookieSet["section"] = section
+        cookieSet["server"] = server
+
+        try:
+            cookie = cherrypy.request.cookie
+            display_mode = cookie[cookie_display_mode].value
+        except KeyError:
+            display_mode = "thumbs"
+            cookieSet[cookie_display_mode] = display_mode
+        
+        # Get the items that are in this section.
+        videos = ps.get_section_items(key)
+                                                      
+        logger.debug('begin')
+        items = self.__build_xml(ps, videos)
+        logger.debug('end')
+                        
+        # Get the viewGroup attribute for the root node.  This determines what type
+        # of section this is.  Values are:
+        #  artist - music sections
+        #  movie  - movie sections
+        #  show   - TV show sections
+        page_type = videos.attrib["viewGroup"]
+        
+        cookieSet["section_type"] = page_type
                 
-                # Get the individual items that make up the playlist.
-                playlist_items = ps.get_playlist_items(playlist_key)
-                
-                # Loop through each item in the playlist.
-                for video in playlist_items:
-                    rating_key = video.get("ratingKey")
-                    playlist_gp_key = video.get("grandparentRatingKey")
-                    
-                    # Check if the grandparent key is populated.  If it is, 
-                    # this item is an episode or song.  In that case, we use
-                    # the grandparent key as that is the TV show or artist that
-                    # this item belongs to.
-                    if not playlist_gp_key:
-                        key_to_use = rating_key
-                    else:
-                        key_to_use = playlist_gp_key
-                    
-                    # Determine if this video has been added to the dictionay.
-                    if pl_dict.has_key(key_to_use):
-                        # Determine if this playlist has been added to the list
-                        # that makes up the value portion of the dictionary 
-                        # item.  This is needed since the playlist can contain 
-                        # multiple episodes/songs from the same show/artist and
-                        # the playlist only needs to be added once to the show/
-                        # artist.
-                        if pl_dict[key_to_use].count(playlist_title) == 0:
-                            pl_dict[key_to_use].append(playlist_title)
-                    else:
-                        pl_dict[key_to_use] = [playlist_title]
-            
-            # Create the dictionary of dictionaries.
-            list_dict = {"genre" : genre_dict, "collection" : coll_dict, "playlist" : pl_dict}
-                            
-            # Get the viewGroup attribute for the root node.  This determines what type
-            # of section this is.  Values are:
-            #  artist - music sections
-            #  movie  - movie sections
-            #  show   - TV show sections
-            page_type = videos.attrib["viewGroup"]
-            
-            cookieSet["section_type"] = page_type
-            
-            section_template = lookup.get_template("section.html")
-            return section_template.render(server=server
-                                          ,page_type=page_type
-                                          ,section=section
-                                          ,videos=videos
-                                          ,display_mode=display_mode
-                                          ,lists=list_dict)  
+        section_template = lookup.get_template("section.html")
+        return section_template.render(server=server
+                                      ,page_type=page_type
+                                      ,section=section
+                                      ,key=key
+                                      ,items=items
+                                      ,display_mode=display_mode)
 
     @cherrypy.expose
     def refresh_servers_redirect(self):
         self.__refresh_servers()
         raise cherrypy.HTTPRedirect("home")
-        #raise cherrypy.HTTPRedirect("error?error=REFRESH_SERVERS")
+        
+    @cherrypy.expose
+    def details(self, server, key):
+        ps = PlexServer(server)
+        
+        if ps.simple_status == "down":
+            raise cherrypy.HTTPRedirect("error?error=SERVER_UNREACHABLE")
+            
+        cookieSet = cherrypy.response.cookie
+        
+        # Retrieve the cookie for the display mode (thumbs or list).
+        cookie_display_mode = "displayMode-" + str(server) + "-" + str(key)
+        cookie_display_mode = urllib2.quote(cookie_display_mode)
+        
+        # Use cookies to save the values of the URL parameters.  This seems 
+        # easier than trying to deconstruct the URL query string in javascript.
+        cookieSet["address"] = ps.address
+        cookieSet["port"] = ps.port
+        cookieSet["key"] = key
+        cookieSet["section"] = ''
+        cookieSet["server"] = server
+        cookieSet[cookie_display_mode] = "list"
+
+        # Get XML for the show.
+        videos = ps.get_video(key)
+        
+        section_title = videos.get('librarySectionTitle')
+        section_key = videos.get('librarySectionID')
+        
+        for video in videos:
+            video_title = video.get('title')
+            page_type = 'details_{0}'.format(video.get('type'))
+            # The guid has the info needed to get data from the scraper website.
+            guid = video.get('guid')
+            
+        logger.debug('page_type : {0}'.format(page_type))
+            
+        # Check the guid to see if it's for thetvdb.
+        if guid.find('thetvdb') > 0:
+            # Extract the key for the video from the guid
+            str_start = guid.find('//') + 2
+            str_end = guid.find('?')
+            thetvdb_key = guid[str_start:str_end]
+            logger.debug('The tv db : {0}'.format(thetvdb_key))
+        
+        items = self.__build_xml(ps, videos)
+        
+        logger.debug(ET.tostring(items))
+        
+        detail_template = lookup.get_template('details.html')
+        return detail_template.render(server=server
+                                     ,key=key
+                                     ,page_type=page_type
+                                     ,section_key=section_key
+                                     ,section_title=section_title
+                                     ,video_title=video_title
+                                     ,items=items)
+                                     
         
 # Configure CherryPy so that the webserver is visible on the LAN, not just the
 # local machine.

--- a/html/body.html
+++ b/html/body.html
@@ -24,55 +24,43 @@
 ##   show   - A TV show section is being displayed
 ##   artist - A music section is being displayed
 ## display_mode - Determines if the page loads with thumbnails or in a list.
+<%page args="server, items='', page_type='movie', display_mode='thumbs'"/>
 
-<%page args="server, videos='', page_type='movie'"/>
-        <div id="results_container">
-            <div id="results">
+<div id="results_container">
+    <div id="results">
+
 <% 
     priorValue = 'xx' 
 %>
 
-% for video in videos:
-    <%
-        video_key = video.get('ratingKey')
-    %>
-    
+% for item in items:
     ## Do not show photo sections, as there's no artwork to update with those  
-    ## sections.
-    % if video.get('type') != 'photo':
+    ## sections.  This check is needed for when processing the sections in a 
+    ## server.  A check before the for loop could be done for sections, but by
+    ## checking it here it makes the logic the same for a server and a section.
+    % if item.get('type') != 'photo':
         <% 
-            ## When creating the navigation section, use the sort title if it's
-            ## available.
-            if video.get('titleSort'):
-                 currentValue = video.get('titleSort')
-            else:
-                 currentValue = video.get('title')
-            
-            video_title = video.get('title')
-                
-            if video.get('childCount') is None:
+
+            ## *********************************************************
+            ## WHAT IS THE POINT OF THIS!
+            ##   ok the check of the xml makes sense becuase if the video
+            ##   doesn't have children it wont' have a childcount tag,
+            ##   but what the heck was I thinking with adding 1 to the
+            ##   the count!!
+            ## *********************************************************                
+            if item.get('childCount') is None:
                 childCount = 1
             else:
-                childCount = int(video.get('childCount'))
+                childCount = int(item.get('childCount'))
                 
             childCount += 1
         %>
-                
-        ## Items that start with a number are all grouped into the pound sign 
-        ## character just like Plex
-        <% 
-            currentValue = currentValue[0:1] 
-            if currentValue in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']:
-                currentValue = '#'
-            else:
-                currentValue = currentValue.upper()
-        %>
         
         ## If the begining letter has changed, create a link for the new letter.
-        % if priorValue != currentValue:
-                <a name="${currentValue}"></a>
+        % if priorValue != item.get('sortLetter'):
+                <a name="${item.get('sortLetter')}"></a>
             <% 
-                priorValue = currentValue 
+                priorValue = item.get('sortLetter') 
             %>
         % endif
         
@@ -101,7 +89,7 @@
             image_height = ''
             title_class = ''
                 
-            if page_type == 'movie' or page_type == 'server':
+            if page_type in ['movie', 'server', 'details_movie']:
                 drawer_image = '' 
                 button_class = 'movie'
                 season_class = ''
@@ -111,7 +99,7 @@
                 title_class = 'video_title2_movie'
                 thumb_type = 'thumb'
             else:
-                drawer_image = '<img id="drawer-' + video.get('ratingKey') + '" src="static/images/arrow.png" class="video_drawer" width="20" height="20">'
+                drawer_image = '<img id="drawer-' + item.get('key') + '" src="static/images/arrow.png" class="video_drawer" width="20" height="20">'
                 button_class = 'tv'
                 title_class = 'video_title2_tv'
             
@@ -122,12 +110,28 @@
                 ## for albums or seasons since one is 100 pixels tall and the 
                 ## other is 150. 
                 if page_type == 'show':
+                    seasons_class = 'seasons_regular'
                     season_class = 'season_block_tv'
                     image_name = 'emptyTVThumb.png'
                     image_height = '150'
                     thumb_type = 'thumb'
             
                 if page_type == 'artist':
+                    seasons_class = 'seasons_regular'
+                    season_class = 'season_block_music'
+                    image_name = 'emptyMusicThumb.png'
+                    image_height = '100'
+                    thumb_type = 'music'
+                    
+                if page_type == 'details_show':
+                    seasons_class = ''
+                    season_class = 'season_block_tv'
+                    image_name = 'emptyTVThumb.png'
+                    image_height = '150'
+                    thumb_type = 'thumb'
+                    
+                if page_type == 'deails_artis':
+                    seasons_class = ''
                     season_class = 'season_block_music'
                     image_name = 'emptyMusicThumb.png'
                     image_height = '100'
@@ -148,60 +152,68 @@
         ## If the page_type is a server, output the images for the
         ## different sections.
         % if page_type == 'server':
-                <div class="item_block">
-                    <div class="item_image" id="image-${video.get('key')}"><a class="item_link" href="../section?server=${server}&key=${video.get('key')}&section=${video_title}"><img src="/image?server=${server}&path=${video.get('art')}&type=background&width=267&height=150" width="267" height="150"></a></div>
-                    <div class="item_title" id="title-${video.get('key')}"><a class="item_link" href="../section?server=${server}&key=${video.get('key')}&section=${video_title}">${video_title}</a></div>
-                </div>
+        <div class="item_block">
+            <div class="item_image" id="image-${item.get('key')}"><a class="item_link" href="../section?server=${server}&key=${item.get('key')}&section=${item.get('title')}"><img src="/image?server=${server}&path=${item.get('art')}&type=background&width=267&height=150" width="267" height="150"></a></div>
+            <div class="item_title" id="title-${item.get('key')}"><a class="item_link" href="../section?server=${server}&key=${item.get('key')}&section=${item.get('title')}">${item.get('title')}</a></div>
+        </div>
         ## For all other page_type values, this is a section in Plex.  Output 
         ## the images for the videos in the section.
         % else:
-                <div class="${video_block_class}video_block" id="block-${video.get('ratingKey')}">
-                    <div class="video_img" id="image-${video.get('ratingKey')}"><img id="thumb-${video.get('ratingKey')}" class="video_thumb ${video_key}" src="/image?server=${server}&path=${video.get('thumb')}&type=${thumb_type}" width="100" height="${image_height}"><img id="art-${video.get('ratingKey')}" class="video_art ${video_key}" src="/image?server=${server}&path=${video.get('art')}&type=background" width="267" height="150">
+        <div class="${video_block_class}video_block" id="block-${item.get('key')}">
+            <div class="video_img" id="image-${item.get('key')}"><img id="thumb-${item.get('key')}" class="video_thumb ${item.get('key')}" src="/image?server=${server}&path=${item.get('thumb')}&type=${thumb_type}" width="100" height="${image_height}"><img id="art-${item.get('key')}" class="video_art ${item.get('key')}" src="/image?server=${server}&path=${item.get('art')}&type=background" width="267" height="150">
+            
+                ## genres/collections/playlists go here
             <%
-                def process_list( list_name):
-                    list_out = ''
-                    list = lists[list_name]
-                    
-                    for key in list:
-                        if key == video.get('ratingKey'):
-                            for list_item in list[key]:
-                                if not list_out:
-                                    list_out = list_item
-                                else:
-                                    list_out = list_out + ' / ' + list_item
-                     
-                    if not list_out:
-                        list_out = 'None'
-                         
-                    return list_out
-                                
-                genre_out = process_list('genre')
-                collection_out = process_list('collection')
-                playlist_out = process_list('playlist')
+                genre_out = 'None'
+                collection_out = 'None'
+                playlist_out = 'None'
                 
+                for l in item.iter('list_item'):
+                    if l.get('type') == 'genre':
+                        if genre_out == 'None':
+                            genre_out = l.get('title')
+                        else:
+                            genre_out += ' / ' + l.get('title')
+                            
+                    if l.get('type') == 'collection':
+                        if collection_out == 'None':
+                            collection_out = l.get('title')
+                        else:
+                            collection_out += ' / ' + l.get('title')
+                    if l.get('type') == 'playlist':  
+                        if playlist_out == 'None':
+                            playlist_out = l.get('title')
+                        else:
+                            playlist_out += ' / ' + l.get('title')        
             %>
-                    <div class="list_details" id="list_details-${video.get('ratingKey')}" ${hide_details}>
-                        <div class="list_genre" id="list_genre-${video.get('ratingKey')}">
-                            <div class="list_title">Genres:</div>
-                            <div class="list_item ${video_key}" id="list_item_genre-${video.get('ratingKey')}">${genre_out}</div>
-                        </div>
-                        <div class="list_collection" id="list_collection-${video.get('ratingKey')}">
-                            <div class="list_title">Collections:</div>
-                            <div class="list_item ${video_key}" id="list_item_collection-${video.get('ratingKey')}">${collection_out}</div>
-                        </div>
-                        <div class="list_playlist" id="list_playlist-${video.get('ratingKey')}">
-                            <div class="list_title">Playlists:</div>
-                            <div class="list_item"id="list_item_playlist-${video.get('ratingKey')}">${playlist_out}</div>
-                        </div>
+            
+                <div class="list_details" id="list_details-${item.get('key')}" ${hide_details}>
+                    <div class="list_genre" id="list_genre-${item.get('key')}">
+                        <div class="list_title">Genres:</div>
+                        <div class="list_item ${item.get('key')}" id="list_item_genre-${item.get('key')}">${genre_out}</div>
+                    </div>
+                    <div class="list_collection" id="list_collection-${item.get('key')}">
+                        <div class="list_title">Collections:</div>
+                        <div class="list_item ${item.get('key')}" id="list_item_collection-${item.get('key')}">${collection_out}</div>
+                    </div>
+                    <div class="list_playlist" id="list_playlist-${item.get('key')}">
+                        <div class="list_title">Playlists:</div>
+                        <div class="list_item"id="list_item_playlist-${item.get('key')}">${playlist_out}</div>
                     </div>
                 </div>
-                    <div class="${video_block_class}video_title" id="title-${video.get('ratingKey')}"><div class="video_title2 ${title_class}">${video_title}</div><div class="refresh refresh_${button_class}">${drawer_image}<img id="refresh-${video.get('ratingKey')}" class="video_refresh" src="static/images/refresh.png" width="20" height="20" alt="Refresh Artwork"></div></div>
+            </div>
+            
+            % if page_type in ['movie', 'show', 'artist']:
+            <div class="${video_block_class}video_title" id="title-${item.get('key')}"><div class="video_title2 ${title_class}"><a href="../details?server=${server}&key=${item.get('key')}" class="video_link">${item.get('title')}</a></div><div class="refresh refresh_${button_class}">${drawer_image}<img id="refresh-${item.get('key')}" class="video_refresh" src="static/images/refresh.png" width="20" height="20" alt="Refresh Artwork"></div></div>
+            % else:
+            <div class="${video_block_class}video_title" id="title-${item.get('key')}"></div>
+            % endif
                     
-            % if page_type == 'show' or page_type == 'artist':
-                    <div class="seasons" id="season-${video.get('ratingKey')}">
+            % if page_type in ['show', 'artist', 'details_show', 'details_artist'] and int(item.get('childCount')) > 0:
+            <div class="seasons ${seasons_class}" id="season-${item.get('key')}">
                 <%
                     seasonHTML = ''
-                    for i in range(1,childCount):
+                    for i in range(0,int(item.get('childCount'))):
                         seasonHTML += '<div class="' + season_class + '">'
                         seasonHTML += '    <div class="season">'
                         seasonHTML += '        <div class="season_img"><img src="/static/images/' + image_name + '" width="100" height="' + image_height + '"></div>'
@@ -210,12 +222,12 @@
                         seasonHTML += '</div>'
                 %>
 ${seasonHTML}
-                    </div>
+            </div>
             % endif
-                </div>
-        % endif 
+        </div>
+        % endif         
     % endif
 % endfor
 
-            </div>
-        </div>
+    </div>
+</div>

--- a/html/body.html
+++ b/html/body.html
@@ -47,6 +47,11 @@
             ##   doesn't have children it wont' have a childcount tag,
             ##   but what the heck was I thinking with adding 1 to the
             ##   the count!!
+            ##
+            ##  The adding 1 is needed for the for loop towards the 
+            ##  bottom.  It uses range, which goes from 0 to childCount
+            ##  and if childCount is incremented by 1 the loop will be 
+            ##  1 iteration short.
             ## *********************************************************                
             if item.get('childCount') is None:
                 childCount = 1

--- a/html/details.html
+++ b/html/details.html
@@ -28,9 +28,12 @@ Input variables to the page:
 
 <%
     ##title = ' : ' + server + ' : ' + section_title + ' : ' + video_title
-    title = ' : {0} : {1} : {2}'.format(server, section_title, video_title)
+    title = u' : {} Details'.format(video_title)
+    
     ##header = ' : <a class="header_link" href="server?server=' + server + '">' + server + '</a> : ' + video_title
-    header = ' : <a class="header_link" href="server?server={0}">{0}</a> : <a class="header_link" href="section?server={0}&key={1}&section={2}">{2}</a> : {3}'.format(server, section_key, section_title, video_title)
+    header = u' : <a class="header_link" href="server?server={0}">{0}</a> : <a class="header_link" href="section?server={0}&key={1}&section={2}">{2}</a> : {3}'.format(server, section_key, section_title, video_title)
+    
+    
     
     js_script = '<script>'
     js_script += '  var gDrawerID = "";'

--- a/html/details.html
+++ b/html/details.html
@@ -1,6 +1,6 @@
 <%doc>
 Uffizi - View all of the artwork for Plex sections at once
-Copyright (C) 2016 Jason Ellis
+Copyright (C) 2017 Jason Ellis
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -17,18 +17,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Input variables to the page:
   server - The name of the server
+  key - The key of the video being rendered.
   page_type - What section is being rendered.  Valid values are music, artist, 
     and show.
-  section - The name of the section
-  key - The key of the section
-  items - The XML containing either all of the items in the section or all of 
-    sections on the server.  Depends on the page_type.   
-  display_mode - Whether the videos should be displayed in a series of thumbs
-    or as a list with additional details. 
+  section_key - The key to the section this video belongs to.
+  section_title - The title of the section this video belong to.
+  video_title - The name of the video being rendered.
+  items - The XML containing the data for the video.
 </%doc>
+
 <%
-    title = ' : ' + server + ' : ' + section
-    header = ' : <a class="header_link" href="server?server=' + server + '">' + server + '</a> : ' + section
+    ##title = ' : ' + server + ' : ' + section_title + ' : ' + video_title
+    title = ' : {0} : {1} : {2}'.format(server, section_title, video_title)
+    ##header = ' : <a class="header_link" href="server?server=' + server + '">' + server + '</a> : ' + video_title
+    header = ' : <a class="header_link" href="server?server={0}">{0}</a> : <a class="header_link" href="section?server={0}&key={1}&section={2}">{2}</a> : {3}'.format(server, section_key, section_title, video_title)
     
     js_script = '<script>'
     js_script += '  var gDrawerID = "";'
@@ -41,9 +43,11 @@ Input variables to the page:
     meta_tags += '<meta name="cols" id="metaCols" content="">'
     meta_tags += '<meta name="server" id="metaServer" content="' + server + '">'
     meta_tags += '<meta name="section_type" id="metaSectionType" content="' + page_type + '">'
-    meta_tags += '<meta name="display_mode" id="metaDisplayMode" content="' + display_mode + '">'
+    meta_tags += '<meta name="display_mode" id="metaDisplayMode" content="list">'
 %>
-<%include file="header.html" args="page_js='section', title=title, header=header, js_script=js_script"/>
-<%include file="navbar.html" args="items=items, page_type=page_type"/>
-<%include file="body.html" args="server=server, items=items, page_type=page_type, display_mode=display_mode"/>
-<%include file="footer.html"/> 
+    
+<%include file="header.html" args="page_js='details', title=title, header=header, js_script=js_script"/>
+<%include file="navbar.html" args="items='', page_type='none'"/>
+<%include file="body.html" args="server=server, items=items, page_type=page_type, display_mode='list'"/>
+<%include file="footer.html" />
+

--- a/html/header.html
+++ b/html/header.html
@@ -18,6 +18,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta charset="UTF-8">
         <link rel="icon" type="image/png" href="/static/images/favicon.png">
         
         <link rel="stylesheet" href="/static/css/style.css" />

--- a/html/navbar.html
+++ b/html/navbar.html
@@ -14,34 +14,17 @@
 ## You should have received a copy of the GNU General Public License
 ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-<%page args="videos='', page_type='none'"/>
+<%page args="items='', page_type='none'"/>
         <div id="navbar">
 <% 
     priorValue = 'xx' 
 %>
-% for video in videos:
-    ## Use the sort title for the video/section if its available.  If the sort 
-    ## title hasn't been set, it will be blank.
-    <% 
-        if video.get('titleSort'):
-            currentValue = video.get('titleSort')
-        else:
-            currentValue = video.get('title')
-    %>          
-    ## Items that start with a number are all grouped into the pound sign 
-    ## character just like Plex does.
-    <% 
-        currentValue = currentValue[0:1] 
-        if currentValue in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']:
-            currentValue = '#'
-        else:
-            currentValue = currentValue.upper()
-    %>
+% for item in items:
     ## If the begining letter has changed, create a link for the new letter.
-    % if priorValue != currentValue:
-            <div class="navbar_block"><a class="navbar_link" href="#${currentValue}">${currentValue}</a></div>
+    % if priorValue != item.get('sortLetter'):
+            <div class="navbar_block"><a class="navbar_link" href="#${item.get('sortLetter')}">${item.get('sortLetter')}</a></div>
         <% 
-            priorValue = currentValue 
+            priorValue = item.get('sortLetter') 
         %>
     % endif
 % endfor

--- a/html/server.html
+++ b/html/server.html
@@ -15,6 +15,6 @@
 ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
     
 <%include file="header.html" args="page_js='server', title=' : ' + server, header=' : ' + server"/>
-<%include file="navbar.html" args="videos=videos"/>
-<%include file="body.html" args="server=server, videos=videos, page_type='server'"/>
+<%include file="navbar.html" args="items=items"/>
+<%include file="body.html" args="server=server, items=items, page_type='server'"/>
 <%include file="footer.html"/>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -269,8 +269,19 @@ a:focus {
   width: 95%;
 }
 
+.video_link:link,
+.video_link:visited {
+  text-decoration: none; 
+  color: #ffffff;
+  font-size: 16px;
+}
+
+.video_link:hover,
+.video_link:focus {
+  text-decoration: underline; 
+}
+
 .seasons {
-  display: none; 
   background: #333333;
   position: relative;  
   float: left;
@@ -280,8 +291,13 @@ a:focus {
   z-index: 1000000;
 }
 
+.seasons_regular {
+  display: none; 
+}
+
 .season_block_tv,
-.season_block_music {
+.season_block_music
+.season_block_details {
   display: inline-block;
   width: 100px;
   margin-right: 10px;
@@ -587,6 +603,19 @@ input:focus {
 
 }
 
+.list_link:link,
+.list_link:visited {
+  color: #ffffff;
+  text-decoration: none; 
+  font-size: 13px;
+  display: inline; 
+}
+
+.list_link:hover,
+.list_link:focus {
+  text-decoration: underline;
+}
+
 /* Everything that appers between this comment and the one below were found
    here: http://joshnh.com/weblog/how-to-make-an-alert-bar/ */
 #alert {
@@ -696,3 +725,12 @@ input:focus {
 }
 
 /* End CSS found at joshnh.com. */
+
+.details_seasons {
+  background: #333333;
+  position: relative;  
+  float: left;
+  padding: 10px;
+  margin-right: 15px;
+  width: 10px;
+}

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -28,3 +28,8 @@ function setDimensions(){
   var resultsHeight = window.innerHeight - 90;
   $('#results').css('height', resultsHeight);
 }
+
+
+function buildMetaDataURL(path) {
+  return '/metadata?server=' + gServer + '&path=' + path
+}

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -30,6 +30,6 @@ function setDimensions(){
 }
 
 
-function buildMetaDataURL(path) {
+function buildMetaDataURL(path) { 
   return '/metadata?server=' + gServer + '&path=' + path
 }

--- a/static/js/details.js
+++ b/static/js/details.js
@@ -1,0 +1,90 @@
+// Uffizi - View all of the artwork for Plex sections at once          
+// Copyright (C) 2016 Jason Ellis                                      
+//                                                                      
+// This program is free software: you can redistribute it and/or modify 
+// it under the terms of the GNU General Public License as published by 
+// the Free Software Foundation, either version 3 of the License, or    
+// (at your option) any later version.                                  
+//                                                                      
+// This program is distributed in the hope that it will be useful,      
+// but WITHOUT ANY WARRANTY; without even the implied warranty of       
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+// GNU General Public License for more details.                         
+//                                                                      
+// You should have received a copy of the GNU General Public License    
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Set the dimensions of items that can change depending on the size of the 
+// browser window.
+function setDimensionsSection() {
+  var seasonTop;
+  var elementID;
+  var seasonID;
+  var stopRowCheck = 0
+  var totalWidth;
+  
+  // Determine what the height of the results DIV should be.  It is the
+  // size of the display area minus the heights of the header and the nav
+  // bar.
+  var resultsHeight = window.innerHeight - 90;
+  $('#results').css('height', resultsHeight);
+  
+  // Set the width of the drawer that shows seasons/albums.
+  if (gSectionType == 'details_show' || gSectionType == 'details_artist') {
+    $('.seasons').css('width', '100%'); 
+  }
+}
+
+function showSeasons() {
+  var seasons = document.getElementsByClassName('seasons'); 
+       
+  // Loop through the list detail elements.
+  for (i=0; i<seasons.length; i++) {  
+    var elementID = getKey(seasons[i].id); 
+    
+    // Get the XML for the seasons for the TV Show
+    $.ajax({
+      type: 'GET',
+      dataType: 'xml',
+      url: buildMetaDataURL('/library/metadata/' + elementID + '/children'),
+      success: parseSeasonXML
+    });
+    
+    function parseSeasonXML(xml) {
+      var result = '';
+      
+      $(xml).find('Directory').each(function()
+      {
+        // Skip the first record
+        if ($(this).attr('parentRatingKey') == elementID) {
+          result += '<div class="' + div_name + '">';
+          result += '    <div class="season">';
+          result += '        <div class="season_img"><img id="seasonImage-' + $(this).attr('ratingKey') + '" class="' + elementID + '" src="/image?server=' + gServer + '&path=' + $(this).attr('thumb') + '&type=thumb' + '" width="100" height="' + img_height + '"></div>';
+          result += '        <div class="season_title">' + $(this).attr('title') + '</div>';
+          result += '    </div>';
+          result += '</div>';
+        }
+      });
+      
+      $('#season-' + elementID).html(result);
+    }
+  }   
+}
+
+$(document).ready(function(){
+  
+  if (gSectionType == 'details_show') {
+    div_name = 'season_block_tv';
+    img_height = '150';
+  }
+  else {
+    div_name = 'season_block_music';
+    img_height = '100'
+  }
+  
+  setDimensionsSection();
+  
+  // Populate the thumbnail images for the seasons.
+  showSeasons();
+  
+});

--- a/static/js/section.js
+++ b/static/js/section.js
@@ -25,14 +25,15 @@ $(document).ready(function(){
       
   function getDisplayModeCookie() {
     // Set the cookie for the page and the display mode.
-    var cookieDisplayMode = 'displayMode-' + Cookies.get('server') + '-' + Cookies.get('key');
+    //var cookieDisplayMode = 'displayMode-' + Cookies.get('server') + '-' + Cookies.get('key');
+    var cookieDisplayMode = 'displayMode-' + gServer + '-' + gKey;
       
     return cookieDisplayMode;
   }
   
-  function buildMetaDataURL(path) {
-    return '/metadata?server=' + gServer + '&path=' + path
-  }
+  //function buildMetaDataURL(path) {
+  //  return '/metadata?server=' + gServer + '&path=' + path
+  //}
   
   function thumbsListToggle(displayMode) {
         
@@ -329,8 +330,8 @@ $(document).ready(function(){
         var thumb = '';
         var art = '';
         var sectionElement = '';
-        var genreOut = '';
-        var collectionOut = '';
+        var genreOut = 'None';
+        var collectionOut = 'None';
         var playlistOut = '';
         
         // Get the information for playlists this item belongs to.  Playlists
@@ -354,17 +355,17 @@ $(document).ready(function(){
           
           if (displayMode == 'list') {
             $(xml).find('Genre').each(function() {
-              if (genreOut) 
-                genreOut = genreOut + ' / ' + $(this).attr('tag');
-              else
+              if (genreOut == 'None') 
                 genreOut = $(this).attr('tag');
+              else
+                genreOut = genreOut + ' / ' + $(this).attr('tag');
             });
             
             $(xml).find('Collection').each(function() {
-              if (collectionOut)
-                collectionOut = collectionOut + ' / ' + $(this).attr('tag');
-              else
+              if (collectionOut == 'None')
                 collectionOut = $(this).attr('tag');
+              else
+                collectionOut = collectionOut + ' / ' + $(this).attr('tag');
             });
           }
         });
@@ -558,8 +559,8 @@ $(document).ready(function(){
       if (!collection)
         collection = 'None'
          
-      $(genreDIV).html(genre);
-      $(collectionDIV).html(collection);
+      //$(genreDIV).html(genre);
+      //$(collectionDIV).html(collection);
     }
   }
 });

--- a/uffizi/api.py
+++ b/uffizi/api.py
@@ -36,34 +36,38 @@ class GetPlaylists(object):
         
         ps = PlexServer(server)
         
-        playlist_out = ""
+        playlist_out = "None"
+        pl_list = []
         
         playlists = ps.get_playlists()
         
         for playlist in playlists:
             playlist_title = playlist.get("title")
             playlist_key = playlist.get("key")
+            playlist_rating_key = playlist.get('ratingKey')
             
+            # Get the individual items that make up the playlist.
             playlist_items = ps.get_playlist_items(playlist_key)
             
             for video in playlist_items:
-                playlist_rating_key = video.get("ratingKey")
-                playlist_gp_key = video.get("grandparentRatingKey")
+                pl_rating_key = video.get("ratingKey")
+                pl_gp_rating_key = video.get("grandparentRatingKey")
                 
                 # Check if the grandparent key is populated.  If it is, 
                 # this item is an episode or song.  In that case, we use
                 # the grandparent key as that is the TV show or artist that
                 # this item belongs to.
-                if not playlist_gp_key:
-                    key_to_use = playlist_rating_key
+                if not pl_gp_rating_key:
+                    key_for_item = pl_rating_key
                 else:
-                    key_to_use = playlist_gp_key
+                    key_for_item = pl_gp_rating_key
                     
-                if key_to_use == rating_key:
-                    if playlist_out:
-                        playlist_out += " / " + playlist_title
-                    else:
-                        playlist_out = playlist_title
+                if key_for_item == rating_key:
+                    if playlist_title not in pl_list:
+                        pl_list.append(playlist_title)
+                            
+        if pl_list:
+            playlist_out = ' / '.join(pl_list)
                 
         return playlist_out
 

--- a/uffizi/plexserver.py
+++ b/uffizi/plexserver.py
@@ -213,10 +213,19 @@ class PlexServer(object):
         
         return self.get_xml(section_path)
         
+    def get_video(self, key):
+        video_path = "library/metadata/{0}".format(key)
+        return self.get_xml(video_path)
+        
+    def get_video_children(self, key):
+        video_path = "library/metadata/{0}/children".format(key)
+        return self.get_xml(video_path)
+        
     def get_playlists(self):
         return self.get_xml("/playlists")
         
     def get_playlist_items(self, key):
+        # For playlist items the "key" contains the path needed for the URL.
         return self.get_xml(key)
         
     def add_server(self, source):
@@ -251,3 +260,8 @@ class PlexServer(object):
         db.update_server_addr(self.server, address, port, valid, always);
         db.commit()
         db.close()
+        
+    def get_filtered_list(self, section_key, filter_name, filter_key):
+        path = 'library/sections/{0}/all'.format(section_key)
+        parms = {filter_name:filter_key}
+        return self.get_xml(path, parms)


### PR DESCRIPTION
Fixes #50
Fixes #49
Fixes #48 
Closes #27 

This partially implements the new details page (#20).  The new page will exist and will show the details that Plex knows about the item, but will not include information from external sources.  Leaving #20 open at this time until those items are added.